### PR TITLE
handle two arguments in gdn+gup

### DIFF
--- a/gitdos.cmd
+++ b/gitdos.cmd
@@ -8,6 +8,6 @@ DOSKEY gr=git remote $*
 DOSKEY gb=git branch $*
 DOSKEY gc=git checkout $1
 DOSKEY gcm=git commit -m $*
-DOSKEY gup=git push origin $1
-DOSKEY gdn=git pull origin $1
+DOSKEY gup=if [$2]==[] (git push origin $1) else (git push $1 $2)
+DOSKEY gdn=if [$2]==[] (git pull origin $1) else (git pull $1 $2)
 DOSKEY gcl=git clone $*


### PR DESCRIPTION
By default, gup and gdn treat a single argument as the branch and default to 'origin':
`gup master => git push origin master`
`gup local master => git push local master`